### PR TITLE
Handling and Styling Markdown generated Tables for Computation Notes

### DIFF
--- a/desktopApp/reactApp/package-lock.json
+++ b/desktopApp/reactApp/package-lock.json
@@ -44,7 +44,7 @@
         "rehype-katex": "^7.0.0",
         "remark-breaks": "^4.0.0",
         "remark-emoji": "^5.0.1",
-        "remark-gfm": "^4.0.0",
+        "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
         "web-vitals": "^2.1.4",
         "xterm": "^5.3.0",
@@ -16729,7 +16729,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
       "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
-      "license": "MIT",
       "dependencies": {
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-gfm-autolink-literal": "^2.0.0",
@@ -16748,7 +16747,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
       "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
-      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "ccount": "^2.0.0",
@@ -16765,7 +16763,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
       "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
-      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "devlop": "^1.1.0",
@@ -17173,7 +17170,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
       "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
-      "license": "MIT",
       "dependencies": {
         "micromark-extension-gfm-autolink-literal": "^2.0.0",
         "micromark-extension-gfm-footnote": "^2.0.0",
@@ -17193,7 +17189,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
       "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
-      "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-sanitize-uri": "^2.0.0",
@@ -17209,7 +17204,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
       "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
-      "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-core-commonmark": "^2.0.0",
@@ -17264,7 +17258,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
       "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
-      "license": "MIT",
       "dependencies": {
         "micromark-util-types": "^2.0.0"
       },
@@ -21184,7 +21177,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
       "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
-      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-gfm": "^3.0.0",
@@ -21251,7 +21243,6 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
       "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
-      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-to-markdown": "^2.0.0",

--- a/desktopApp/reactApp/package.json
+++ b/desktopApp/reactApp/package.json
@@ -40,7 +40,7 @@
     "rehype-katex": "^7.0.0",
     "remark-breaks": "^4.0.0",
     "remark-emoji": "^5.0.1",
-    "remark-gfm": "^4.0.0",
+    "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "web-vitals": "^2.1.4",
     "xterm": "^5.3.0",

--- a/desktopApp/reactApp/src/App.css
+++ b/desktopApp/reactApp/src/App.css
@@ -224,7 +224,7 @@ input[type="file"]::-webkit-file-upload-button:hover {
   background-color: #0066cc; /* Slightly darker blue for hover effect */
 }
 
-.markdown-wrapper h1, 
+/* .markdown-wrapper h1, 
 .markdown-wrapper h2,
 .markdown-wrapper h3,
 .markdown-wrapper strong,
@@ -235,6 +235,50 @@ input[type="file"]::-webkit-file-upload-button:hover {
 .markdown-wrapper h2 {
   line-height: 1.2;
   margin-bottom: 0.5rem;
+} */
+
+.markdown-wrapper code {
+  width: auto;
+  padding: 0.2rem 0.4rem;
+  display: inline;
+  border-radius: 0;
+  font-family: monospace;
+}
+
+.markdown-wrapper .table-wrapper {
+  max-width: 100%;
+  overflow: auto;
+}
+
+.markdown-wrapper table {
+  background-color: transparent;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+.markdown-wrapper table thead tr th {
+  white-space: nowrap;
+}
+
+.markdown-wrapper table td {
+    border-top: 1px solid #dcdcdc;
+}
+
+.markdown-wrapper table td, 
+.markdown-wrapper table th {
+    border-right: 1px solid #dcdcdc;
+    padding: 8px 12px;
+}
+
+.markdown-wrapper table td:last-child, 
+.markdown-wrapper table th:last-child {
+    border-right: 0;
+}
+
+/* Style all body cells in the same column */
+td[data-col="description"] {
+  min-width: 250px;
+  text-align: left;
 }
 
 .toast-container > div {

--- a/desktopApp/reactApp/src/App.css
+++ b/desktopApp/reactApp/src/App.css
@@ -275,6 +275,11 @@ input[type="file"]::-webkit-file-upload-button:hover {
     border-right: 0;
 }
 
+.markdown-wrapper ul, 
+.markdown-wrapper ol {
+  margin-left: 1.25rem;
+}
+
 /* Style all body cells in the same column */
 td[data-col="description"] {
   min-width: 250px;

--- a/desktopApp/reactApp/src/pages/ComputationDetails/ComputationDetailsPage.tsx
+++ b/desktopApp/reactApp/src/pages/ComputationDetails/ComputationDetailsPage.tsx
@@ -1,103 +1,165 @@
-import { useNavigate } from 'react-router-dom';
-import { Alert, Box, Button, Card, Container, IconButton, Typography } from "@mui/material";
+import { useNavigate } from "react-router-dom";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  Container,
+  IconButton,
+  Typography,
+} from "@mui/material";
 import { useComputationDetails } from "./useComputationDetails";
-import ReactMarkdown from 'react-markdown';
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import { useState } from "react";
-
+import React, { useEffect, useRef, useState } from "react";
+import ReactMarkdown, { Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 
 export default function ComputationDetails() {
-    const navigate = useNavigate();
+  const navigate = useNavigate();
+  const { computationDetails, loading, error } = useComputationDetails();
+  const [copied, setCopied] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
 
-    const { computationDetails, loading, error } = useComputationDetails();
+  const handleCopy = () => {
+    if (computationDetails?.imageDownloadUrl) {
+      navigator.clipboard.writeText(computationDetails.imageDownloadUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
 
-    const [copied, setCopied] = useState(false);
+  const slugify = (s: string) =>
+    s.toLowerCase().trim().replace(/\s+/g, "-").replace(/[^a-z0-9\-]/g, "");
 
-    const handleCopy = () => {
-        if (computationDetails.imageDownloadUrl) {
-            navigator.clipboard.writeText(computationDetails.imageDownloadUrl);
-            setCopied(true);
-            setTimeout(() => setCopied(false), 2000); // Reset copy status after 2 seconds
-        }
-    };
+  // --- react-markdown custom renderers ---
+  const markdownComponents: Components = {
+    th: ({ children, ...props }) => {
+      // derive a stable slug from header text
+      const text =
+        Array.isArray(children)
+          ? children.map((c) => (typeof c === "string" ? c : "")).join("").trim()
+          : typeof children === "string"
+          ? children.trim()
+          : "";
+      const dataCol = slugify(text || "col");
+      return (
+        <th {...props} data-col={dataCol}>
+          {children}
+        </th>
+      );
+    },
+    table: ({ ...props }) => (
+      <div className="table-wrapper">
+        <table {...props} />
+      </div>
+    ),
+  };
 
-    return (
-        <Box p={2}>
-            {/* Error State */}
-            {error && (
-                <Box mt={2}>
-                    <Alert severity="error">{error}</Alert>
-                </Box>
-            )}
+  // --- Propagate data-col from <th> to the corresponding <td> cells ---
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
 
-            {/* Run Details Display */}
-            {computationDetails && (
-                <Container maxWidth="lg" sx={{marginTop: '1rem'}}>
-                    <Box display="flex" justifyContent="space-between" marginLeft="1rem" marginRight="1rem">
-                        <Typography variant="h4">
-                            Computation Details
-                        </Typography>
-                        <Box>
-                            <Button 
-                                variant="outlined" 
-                                onClick={() => navigate(`/computation/list/`)}
-                            >
-                                Back To Computation List
-                            </Button>
-                        </Box>
-                    </Box>
-                    <Card style={{margin: '1rem', padding: '2rem'}}>
-                        <Typography variant="h5" fontWeight="600" color="black">{computationDetails.title}</Typography>
-                        <Typography variant="body2" color="textSecondary">
-                            {computationDetails.imageName}
-                        </Typography>
-                        <Box marginTop={2} display="flex" flexDirection="column" alignItems="flex-start">
-                        <Typography>
-                            Image Download:
-                        </Typography>
-                        <Box display="flex" alignItems="center" marginBottom="1rem">
-                            <Typography
-                                component="code"
-                                sx={{
-                                    bgcolor: '#f5f5f5',
-                                    padding: '4px 8px',
-                                    borderRadius: 1,
-                                    fontFamily: 'monospace',
-                                    fontSize: '0.875rem',
-                                    width: 'calc(100% - 2rem)',
-                                    lineBreak: 'anywhere'
-                                }}
-                            >
-                                {computationDetails.imageDownloadUrl}
-                            </Typography>
-                            <IconButton
-                                onClick={handleCopy}
-                                size="small"
-                                aria-label="copy download URL"
-                                sx={{ marginLeft: 1 }}
-                            >
-                                <ContentCopyIcon fontSize="small" />
-                            </IconButton>
-                            {copied && (
-                                <Typography fontSize="0.75rem" color="green" marginLeft={1}>
-                                    Copied!
-                                </Typography>
-                            )}
-                        </Box>
-                    </Box>
-                        <Box marginTop="1rem">
-                            <ReactMarkdown>{computationDetails.notes}</ReactMarkdown>
-                        </Box>                       
-                    </Card>
-                </Container>
-            )}
+    root.querySelectorAll("table").forEach((table) => {
+      const headerRow = table.querySelector("thead tr");
+      if (!headerRow) return;
 
-            {/* Fallback in case data is undefined and not loading */}
-            {!loading && !computationDetails && !error && (
-                <Typography variant="body1" color="textSecondary">
-                    No run details available.
-                </Typography>
-            )}
+      const ths = Array.from(
+        headerRow.querySelectorAll<HTMLTableCellElement>("th")
+      );
+      const headerSlugs = ths.map((th) => th.getAttribute("data-col") || "");
+
+      Array.from(table.querySelectorAll("tbody tr")).forEach((tr) => {
+        const tds = Array.from(tr.querySelectorAll<HTMLTableCellElement>("td"));
+        tds.forEach((td, i) => {
+          const slug = headerSlugs[i];
+          if (slug) td.setAttribute("data-col", slug);
+        });
+      });
+    });
+  }, [computationDetails?.notes]); // re-run when markdown changes
+
+  return (
+    <Box p={2}>
+      {error && (
+        <Box mt={2}>
+          <Alert severity="error">{error}</Alert>
         </Box>
-    );
+      )}
+
+      {computationDetails && (
+        <Container maxWidth="lg" sx={{ marginTop: "1rem" }}>
+          <Box display="flex" justifyContent="space-between" mx="1rem">
+            <Typography variant="h4">Computation Details</Typography>
+            <Box>
+              <Button
+                variant="outlined"
+                onClick={() => navigate(`/computation/list/`)}
+              >
+                Back To Computation List
+              </Button>
+            </Box>
+          </Box>
+
+          <Card sx={{ m: "1rem", p: "2rem" }}>
+            <Typography variant="h5" fontWeight={600} color="black">
+              {computationDetails.title}
+            </Typography>
+            <Typography variant="body2" color="textSecondary">
+              {computationDetails.imageName}
+            </Typography>
+
+            <Box mt={2} display="flex" flexDirection="column" alignItems="flex-start">
+              <Typography>Image Download:</Typography>
+              <Box display="flex" alignItems="center" mb="1rem" width="100%">
+                <Typography
+                  component="code"
+                  sx={{
+                    bgcolor: "#f5f5f5",
+                    p: "4px 8px",
+                    borderRadius: 1,
+                    fontFamily: "monospace",
+                    fontSize: "0.875rem",
+                    width: "calc(100% - 2rem)",
+                    lineBreak: "anywhere",
+                  }}
+                >
+                  {computationDetails.imageDownloadUrl}
+                </Typography>
+                <IconButton
+                  onClick={handleCopy}
+                  size="small"
+                  aria-label="copy download URL"
+                  sx={{ ml: 1 }}
+                >
+                  <ContentCopyIcon fontSize="small" />
+                </IconButton>
+                {copied && (
+                  <Typography fontSize="0.75rem" color="green" ml={1}>
+                    Copied!
+                  </Typography>
+                )}
+              </Box>
+            </Box>
+
+            <Box mt="1rem" ref={rootRef}>
+              <ReactMarkdown
+                className="markdown-wrapper"
+                components={markdownComponents}
+                remarkPlugins={[remarkGfm]}
+              >
+                {computationDetails.notes}
+              </ReactMarkdown>
+            </Box>
+          </Card>
+        </Container>
+      )}
+
+      {!loading && !computationDetails && !error && (
+        <Typography variant="body1" color="textSecondary">
+          No run details available.
+        </Typography>
+      )}
+    </Box>
+  );
 }

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/ComputationDisplay/ComputationDisplay.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/ComputationDisplay/ComputationDisplay.tsx
@@ -1,46 +1,108 @@
+import React, { useEffect, useRef, useMemo } from "react";
 import { Computation } from "../../../apis/centralApi/generated/graphql";
 import { Box, Typography, Card, CardContent } from "@mui/material";
 import { Maybe } from "graphql/jsutils/Maybe";
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { useConsortiumDetailsContext } from "../ConsortiumDetailsContext";
 
+const slugify = (s: string) =>
+  s.toLowerCase().trim().replace(/\s+/g, "-").replace(/[^a-z0-9\-]/g, "");
 
-const ComputationDisplay: React.FC<{notesHeading: boolean}> = ({ notesHeading}) => {
-    const {data: consortiumDetails} = useConsortiumDetailsContext();
-    const computation = consortiumDetails?.studyConfiguration?.computation as Maybe<Computation>;
+const ComputationDisplay: React.FC<{ notesHeading: boolean }> = ({ notesHeading }) => {
+  const { data: consortiumDetails } = useConsortiumDetailsContext();
+  const computation = consortiumDetails?.studyConfiguration?.computation as Maybe<Computation>;
 
-    if (!computation) {
-        return (
-            <Card>
-                <CardContent>
-                    <Typography fontSize="11px">Computation Notes:</Typography>
-                </CardContent>
-            </Card>
-        );
-    }
-
-    const { title, notes, imageName } = computation;
-
+  if (!computation) {
     return (
-        <Box
-            className="computation-notes"
-            borderRadius={2}
-            marginBottom={2}
-            bgcolor={'white'}
-        >
-            <div id="compnotes" />{/* For Notes anchor placement at 800px wide */}
-            <CardContent>
-                {notesHeading && <Typography fontSize="11px">Computation Notes:</Typography>}
-                <Typography variant="h5" fontWeight="600" color="black">{title}</Typography>
-                <Typography variant="body2" color="textSecondary">
-                    {imageName}
-                </Typography>
-                <Box marginTop="1rem">
-                    <ReactMarkdown>{notes}</ReactMarkdown>
-                </Box>
-            </CardContent>
-        </Box>
+      <Card>
+        <CardContent>
+          <Typography fontSize="11px">Computation Notes:</Typography>
+        </CardContent>
+      </Card>
     );
-}
+  }
+
+  const { title, notes, imageName } = computation;
+
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  // React-Markdown custom renderers
+  const markdownComponents: Components = useMemo(
+    () => ({
+      th: ({ children, ...props }) => {
+        const text =
+          Array.isArray(children)
+            ? children.map((c) => (typeof c === "string" ? c : "")).join("").trim()
+            : typeof children === "string"
+            ? children.trim()
+            : "";
+        const dataCol = slugify(text || "col");
+        return (
+          <th {...props} data-col={dataCol}>
+            {children}
+          </th>
+        );
+      },
+      table: ({ ...props }) => (
+        <div className="table-wrapper">
+          <table {...props} />
+        </div>
+      ),
+    }),
+    []
+  );
+
+  // Propagate data-col from <th> to matching <td> cells
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    root.querySelectorAll("table").forEach((table) => {
+      const headerRow = table.querySelector("thead tr");
+      if (!headerRow) return;
+
+      const ths = Array.from(headerRow.querySelectorAll<HTMLTableCellElement>("th"));
+      const headerSlugs = ths.map((th) => th.getAttribute("data-col") || "");
+
+      Array.from(table.querySelectorAll("tbody tr")).forEach((tr) => {
+        const tds = Array.from(tr.querySelectorAll<HTMLTableCellElement>("td"));
+        tds.forEach((td, i) => {
+          const slug = headerSlugs[i];
+          if (slug) td.setAttribute("data-col", slug);
+        });
+      });
+    });
+  }, [notes]); // re-run when markdown changes
+
+  return (
+    <Box
+      className="computation-notes"
+      borderRadius={2}
+      marginBottom={2}
+      bgcolor={"white"}
+    >
+      <div id="compnotes" />{/* For Notes anchor placement at 800px wide */}
+      <CardContent>
+        {notesHeading && <Typography fontSize="11px">Computation Notes:</Typography>}
+        <Typography variant="h5" fontWeight="600" color="black">
+          {title}
+        </Typography>
+        <Typography variant="body2" color="textSecondary">
+          {imageName}
+        </Typography>
+        <Box marginTop="1rem" ref={rootRef}>
+            <ReactMarkdown 
+              className="markdown-wrapper"
+              components={markdownComponents} 
+              remarkPlugins={[remarkGfm]}
+            >
+              {notes ?? ""}
+            </ReactMarkdown>
+        </Box>
+      </CardContent>
+    </Box>
+  );
+};
 
 export default ComputationDisplay;


### PR DESCRIPTION
These were not rendering in Computation Notes and then when rendered, were not pretty. 

Here's how they look now:

<img width="1084" height="355" alt="Screenshot 2025-08-21 at 6 35 24 AM" src="https://github.com/user-attachments/assets/3a3a1346-f8c7-4f35-8934-f9a32afc1cca" />
